### PR TITLE
[#12] Update links to wiki and docs from homepage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,18 @@ Link to [twisted.github.io](https://twisted.github.io).
 ## Tools used
 
 This project is using [Tailwind v3](https://tailwindcss.com/docs/) in the
-**404.html** page.
+*404.html* page.
 Use the `tw-` prefix with Tailwind CSS classes.
 
 Node/npm is required to update the */build/css/tailwind.css* file.
+
 Use this command when developing for the CSS file to be updated automatically
 with your Tailwind classes:
-`npm run dev`
+```
+npm run dev
+```
+
 To minify the file run:
-`npm run build`
+```
+npm run build
+```

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -30,15 +30,12 @@ body {
 .logo {
   height: 80px;
 }
-.display-4 {
-  font-weight: 600;
-}
 section {
   padding: 6rem 0;
 }
 .ribbon {
   position: absolute;
-  top: 105px;
+  top: 107px;
   right: 0;
 }
 .bd-clipboard {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -126,10 +126,16 @@ pre code.hljs {
   background-color: #388659;
   border-color: #388659;
 }
-.btn-primary:hover {
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary:not(:disabled):not(.disabled):active {
   color: #fff;
   background-color: #2d6b47;
   border-color: #296241;
+}
+.btn-primary:focus,
+.btn-primary:not(:disabled):not(.disabled):active:focus {
+  box-shadow:  0 0 0.2rem 0.2rem rgb(45 107 71 / 50%)
 }
 .btn {
   font-weight: 600;

--- a/build/css/tailwind.css
+++ b/build/css/tailwind.css
@@ -42,7 +42,7 @@
   --tw-backdrop-invert:  ;
   --tw-backdrop-opacity:  ;
   --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:
+  --tw-backdrop-sepia:  
 }
 
 ::-webkit-backdrop {
@@ -89,7 +89,7 @@
   --tw-backdrop-invert:  ;
   --tw-backdrop-opacity:  ;
   --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:
+  --tw-backdrop-sepia:  
 }
 
 ::backdrop {
@@ -136,7 +136,7 @@
   --tw-backdrop-invert:  ;
   --tw-backdrop-opacity:  ;
   --tw-backdrop-saturate:  ;
-  --tw-backdrop-sepia:
+  --tw-backdrop-sepia:  
 }
 
 .tw-m-0 {

--- a/index.html
+++ b/index.html
@@ -20,10 +20,18 @@
             <div class="col flex-fill px-0 d-flex justify-content-between">
               <a class="navbar-brand" href="/" title="Twisted">
                 <img src="assets/images/twisted-logo-small.svg" alt="Twisted" class="logo"/>
-                <h1 class="d-inline align-middle">Twisted</h2>
+                <h1 class="d-inline align-middle">Twisted</h1>
               </a>
 
-              <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+              <button
+                class="navbar-toggler"
+                type="button"
+                data-toggle="collapse"
+                data-target=".navbar-collapse"
+                aria-controls="navbarNav"
+                aria-expanded="false"
+                aria-label="Toggle navigation"
+                >
                 <span class="navbar-toggler-icon"></span>
               </button>
             </div>
@@ -31,19 +39,30 @@
             <div class="collapse navbar-collapse">
               <ul class="navbar-nav mr-auto">
                 <li class="nav-item">
-                  <a class="nav-link" href="https://twistedmatrix.com/trac/wiki/FrequentlyAskedQuestions">FAQ</a>
+                  <a class="nav-link"
+                    href="https://github.com/twisted/trac-wiki-archive/FrequentlyAskedQuestions">
+                    FAQ
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="https://docs.twistedmatrix.com/">Docs</a>
+                  <a class="nav-link" href="https://docs.twistedmatrix.com/">
+                    Docs
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="https://pypi.org/project/Twisted/">Download</a>
+                  <a class="nav-link" href="https://pypi.org/project/Twisted/">
+                    Download
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="#about">About</a>
+                  <a class="nav-link" href="#about">
+                    About
+                  </a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="#donate">Donate</a>
+                  <a class="nav-link" href="#donate">
+                    Donate
+                  </a>
                 </li>
               </ul>
             </div>
@@ -58,11 +77,14 @@
       <div class="container">
         <div class="row justify-content-center text-center mb-2">
           <div class="col-xl-10 col-lg-10 col-md-10">
-            <h1 class="display-4">An event-driven networking engine written in Python </h1>
+            <h1 class="display-4">
+              An event-driven networking engine written in Python
+            </h1>
             <p class="lead">Licensed under the open source MIT License</p>
 
             <div class="d-flex flex-md-row flex-column justify-content-center align-items-center my-4">
-              <a href="https://github.com/twisted/twisted" class="btn btn-lg btn-outline-dark mx-3 mb-2 mb-md-0">
+              <a href="https://github.com/twisted/twisted"
+                class="btn btn-lg btn-outline-dark mx-3 mb-2 mb-md-0">
                 <i class="bi bi-github"></i>
                 <span>View Github</span>
               </a>
@@ -94,18 +116,57 @@
       </div>
     </section>
 
-
     <section class="has-divider">
       <div class="container">
         <div class="row justify-content-center">
           <div class="col">
             <nav>
               <div class="nav nav-pills nav-fill" id="nav-tab" role="tablist">
-                <a class="nav-item nav-link active" id="nav-echo-server-tab" data-toggle="tab" href="#nav-echo-server" role="tab" aria-controls="nav-echo-server" aria-selected="true">Echo Server</a>
-                <a class="nav-item nav-link" id="nav-web-server-tab" data-toggle="tab" href="#nav-web-server" role="tab" aria-controls="nav-web-server" aria-selected="false">Web Server</a>
-                <a class="nav-item nav-link" id="nav-publish-tab" data-toggle="tab" href="#nav-publish" role="tab" aria-controls="nav-publish" aria-selected="false">Publish/Subscribe</a>
-                <a class="nav-item nav-link" id="nav-mail-tab" data-toggle="tab" href="#nav-mail" role="tab" aria-controls="nav-mail" aria-selected="false">Mail Client</a>
-                <a class="nav-item nav-link" id="nav-ssh-tab" data-toggle="tab" href="#nav-ssh" role="tab" aria-controls="nav-ssh" aria-selected="false">SSH Client</a>
+                <a class="nav-item nav-link active"
+                  id="nav-echo-server-tab"
+                  data-toggle="tab"
+                  href="#nav-echo-server"
+                  role="tab"
+                  aria-controls="nav-echo-server"
+                  aria-selected="true">
+                  Echo Server
+                </a>
+                <a class="nav-item nav-link"
+                  id="nav-web-server-tab"
+                  data-toggle="tab"
+                  href="#nav-web-server"
+                  role="tab"
+                  aria-controls="nav-web-server"
+                  aria-selected="false">
+                  Web Server
+                </a>
+                <a class="nav-item nav-link"
+                  id="nav-publish-tab"
+                  data-toggle="tab"
+                  href="#nav-publish"
+                  role="tab"
+                  aria-controls="nav-publish"
+                  aria-selected="false">
+                  Publish/Subscribe
+                </a>
+                <a class="nav-item nav-link"
+                  id="nav-mail-tab"
+                  data-toggle="tab"
+                  href="#nav-mail"
+                  role="tab"
+                  aria-controls="nav-mail"
+                  aria-selected="false">
+                  Mail Client
+                </a>
+                <a class="nav-item nav-link"
+                  id="nav-ssh-tab"
+                  data-toggle="tab"
+                  href="#nav-ssh"
+                  role="tab"
+                  aria-controls="nav-ssh"
+                  aria-selected="false">
+                  SSH Client
+                </a>
               </div>
             </nav>
             <div class="tab-content" id="nav-tabContent">
@@ -131,10 +192,13 @@ reactor.run()
                 </pre>
                 <p>
                   Learn more about
-                  <a href="https://twistedmatrix.com/documents/current/core/howto/servers.html">writing servers</a>,
-                  <a href="https://twistedmatrix.com/documents/current/core/howto/clients.html"> writing clients</a>
-                  and the
-                  <a href="https://twistedmatrix.com/documents/current/core/howto/index.html">core networking libraries</a>, including support for SSL, UDP, scheduled events, unit testing infrastructure, and much more.
+                  <a href="https://twistedmatrix.com/documents/current/core/howto/servers.html">
+                    writing servers</a>,
+                  <a href="https://twistedmatrix.com/documents/current/core/howto/clients.html">
+                    writing clients</a> and the
+                  <a href="https://twistedmatrix.com/documents/current/core/howto/index.html">
+                    core networking libraries</a>, including support for
+                    SSL, UDP, scheduled events, unit testing infrastructure, and much more.
                 </p>
               </div>
               <div class="tab-pane fade" id="nav-web-server" role="tabpanel" aria-labelledby="nav-web-server-tab">
@@ -162,10 +226,12 @@ reactor.run()
                 </pre>
                 <p>
                   Learn more about
-                  <a href="https://twistedmatrix.com/documents/current/web/howto/web-in-60/index.html">web application development</a>,
-                  <a href="https://twistedmatrix.com/documents/current/web/howto/twisted-templates.html"> templates</a>
-                   and Twisted's
-                   <a href="https://twistedmatrix.com/documents/current/web/howto/client.html">HTTP client</a>.
+                  <a href="https://twistedmatrix.com/documents/current/web/howto/web-in-60/index.html">
+                    web application development</a>,
+                  <a href="https://twistedmatrix.com/documents/current/web/howto/twisted-templates.html">
+                    templates</a> and Twisted's
+                  <a href="https://twistedmatrix.com/documents/current/web/howto/client.html">
+                    HTTP client</a>.
                 </p>
               </div>
               <div class="tab-pane fade" id="nav-publish" role="tabpanel" aria-labelledby="nav-publish-tab">
@@ -245,12 +311,17 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   <a class="ext-link" href="https://support.google.com/accounts/answer/185833?hl=en">generate one for gmail</a>,
                   <a class="ext-link" href="https://www.fastmail.com/help/clients/apppassword.html">generate one for fastmail</a>), and
                   <a class="ext-link" href="https://twistedmatrix.com/documents/current/core/howto/endpoints.html#auto7">
-                    client endpoint description</a>
+                    client endpoint description
+                  </a>
                     for your IMAP4 server.  You'll see the subject of the first message in your mailbox printed.
-                  </p>
-                  <p>
-                  See the <a class="wiki" href="https://twistedmatrix.com/trac/wiki/TwistedMail">TwistedMail</a> documentation for more information.
-                  </p>
+                </p>
+                <p>
+                  See the
+                  <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/TwistedMail">
+                    TwistedMail
+                  </a>
+                  documentation for more information.
+                </p>
               </div>
               <div class="tab-pane fade" id="nav-ssh" role="tabpanel" aria-labelledby="nav-ssh-tab">
                 <p>
@@ -286,7 +357,9 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   </code>
                 </pre>
                 <p>
-                  You can use this client to run "hello world" on any SSH server that your local SSH agent can authenticate to, if you pass your username, host name, and optionally port number on the command line.
+                  You can use this client to run "hello world" on any SSH server
+                  that your local SSH agent can authenticate to,
+                  if you pass your username, host name, and optionally port number on the command line.
                 </p>
               </div>
             </div>
@@ -311,11 +384,16 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
             <div class="ml-2">
               <h3>More Protocols</h3>
               <p>
-                Twisted also supports many common network protocols, including SMTP, POP3, IMAP, SSHv2, and DNS.
+                Twisted also supports many common network protocols,
+                including SMTP, POP3, IMAP, SSHv2, and DNS.
                 </p>
                 <p>For more information see our
-                <a class="wiki" href="https://docs.twistedmatrix.com/">documentation</a> and
-                <a class="ext-link" href="https://twistedmatrix.com/documents/current/api/">API reference</a>.
+                <a class="wiki" href="https://docs.twistedmatrix.com/">
+                  documentation
+                </a>
+                and
+                <a class="ext-link" href="https://twistedmatrix.com/documents/current/api/">
+                  API reference</a>.
               </p>
             </div>
           </div>
@@ -324,7 +402,20 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
             <div class="ml-2">
               <h3>Community</h3>
               <p>
-                Get in touch with the <a class="wiki" href="https://twistedmatrix.com/trac/wiki/TwistedCommunity">Twisted community</a> through <a class="wiki" href="https://twistedmatrix.com/trac/wiki/TwistedCommunity#MailLists">email</a>, <a class="ext-link" href="https://stackoverflow.com/questions/tagged/twisted">Stack Overflow</a> or <a class="wiki" href="https://twistedmatrix.com/trac/wiki/TwistedCommunity#IRC">IRC</a>.
+                Get in touch with the
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/TwistedCommunity">
+                  Twisted community
+                </a>
+                through
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/TwistedCommunity.mediawiki#MailLists">
+                  email
+                </a>,
+                <a class="ext-link" href="https://stackoverflow.com/questions/tagged/twisted">
+                  Stack Overflow
+                </a>
+                or
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/TwistedCommunity.mediawiki#IRC">
+                  IRC</a>.
               </p>
             </div>
           </div>
@@ -333,10 +424,17 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
             <div class="ml-2">
               <h3>Contribute</h3>
               <p>
-                Learn about the Twisted <a class="wiki" href="https://twistedmatrix.com/trac/wiki/TwistedDevelopment">development process</a> and how to <a class="wiki" href="https://twistedmatrix.com/trac/wiki/ContributingToTwistedLabs">contribute</a>.
+                Learn about the Twisted
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/TwistedDevelopment">
+                  development process</a>
+                  and how to
+                  <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/ContributingToTwistedLabs">
+                    contribute</a>.
               </p>
               <p>
-                Help improve Twisted on <a class="wiki" href="https://twistedmatrix.com/trac/wiki/Windows">Windows</a>!
+                Help improve Twisted on
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/Windows">
+                  Windows</a>!
               </p>
             </div>
           </div>
@@ -345,7 +443,15 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
             <div class="ml-2">
               <h3>Wiki</h3>
                <p>
-                Read about <a class="wiki" href="https://twistedmatrix.com/trac/wiki/ProjectsUsingTwisted">software using</a> Twisted and their <a class="wiki" href="https://twistedmatrix.com/trac/wiki/SuccessStories">success stories</a>.
+                Read about
+                <a
+                  class="wiki"
+                  href="https://github.com/twisted/trac-wiki-archive/ProjectsUsingTwisted">
+                  software using
+                </a>
+                Twisted and their
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/SuccessStories">
+                  success stories</a>.
               </p>
             </div>
           </div>
@@ -354,7 +460,13 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
             <div class="ml-2">
               <h3>Sponsors</h3>
               <p>
-                Learn about the <a class="wiki" href="https://twistedmatrix.com/trac/wiki/TwistedSponsors">individuals and organisations</a> that aid Twisted with donations of hardware, software, hosting and other things.
+                Learn about the
+                <a
+                  class="wiki"
+                  href="https://github.com/twisted/trac-wiki-archive/TwistedSponsors">
+                  individuals and organisations
+                </a>
+                that aid Twisted with donations of hardware, software, hosting and other things.
               </p>
             </div>
           </div>
@@ -363,7 +475,12 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
             <div class="ml-2">
               <h3>Twisted Matrix Laboratories</h3>
               <p>
-                Find out what <a class="wiki" href="https://twistedmatrix.com/trac/wiki/TwistedMatrixLaboratories">Twisted Matrix Laboratories</a> is.
+                Find out what
+                <a
+                  class="wiki"
+                  href="https://github.com/twisted/trac-wiki-archive/TwistedMatrixLaboratories">
+                  Twisted Matrix Laboratories
+                </a>is.
               </p>
             </div>
           </div>
@@ -382,7 +499,15 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                 </div>
                 <div>
                   <h4>See our code on Github</h4>
-                  <p>See the code <a class="ext-link" href="https://github.com/twisted/twisted"><span class="icon"></span>for Twisted</a> (<a class="ext-link" href="https://github.com/twisted"><span class="icon"></span>and more</a>) on GitHub</p>
+                  <p>See the code
+                    <a class="ext-link" href="https://github.com/twisted/twisted">
+                      <span class="icon"></span>for Twisted
+                    </a> (
+                      <a class="ext-link" href="https://github.com/twisted">
+                        <span class="icon"></span>
+                        and more
+                      </a>) on GitHub.
+                  </p>
                 </div>
               </div>
               <div class="col-md-6 d-flex mb-4">
@@ -393,10 +518,14 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   <h4>Supported Python</h4>
                   <p class="mb-0">It supports CPython 3.6+ and PyPy3.</p>
                   <p class="mb-0">
-                    <a href="https://github.com/twisted/twisted/releases/tag/twisted-21.2.0">Twisted 21.2.0</a> was the last version with Python 3.5 support.
+                    <a href="https://github.com/twisted/twisted/releases/tag/twisted-21.2.0">
+                      Twisted 21.2.0
+                    </a> was the last version with Python 3.5 support.
                   </p>
                   <p class="mb-0">
-                    <a href="https://labs.twistedmatrix.com/2020/03/twisted-drops-python-27-support.html" >Twisted 20.3.0</a> was the last version with Python 2.7 and PyPy2 support.
+                    <a href="https://labs.twistedmatrix.com/2020/03/twisted-drops-python-27-support.html">
+                      Twisted 20.3.0
+                    </a> was the last version with Python 2.7 and PyPy2 support.
                   </p>
                 </div>
               </div>
@@ -405,7 +534,11 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   <i class="icon bi bi-twitter text-primary"></i>
                 </div>
                 <div>
-                  <h4>Follow us on <a href="https://twitter.com/twistedmatrix">Twitter</a></h4>
+                  <h4>Follow us on
+                    <a href="https://twitter.com/twistedmatrix">
+                      Twitter
+                    </a>
+                  </h4>
                 </div>
               </div>
 
@@ -414,7 +547,11 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   <i class="icon bi bi-shield-lock-fill text-primary"></i>
                 </div>
                 <div>
-                  <h4>Report a <a href="https://twistedmatrix.com/trac/wiki/Security">security issue</a></h4>
+                  <h4>Report a
+                    <a href="https://github.com/twisted/twisted/security/policy">
+                      security issue
+                    </a>
+                  </h4>
                 </div>
               </div>
               <div class="col-md-6 d-flex mb-4 align-items-center">
@@ -422,7 +559,11 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   <i class="icon bi bi-stack text-primary"></i>
                 </div>
                 <div>
-                  <h4>Ask on <a href="https://stackoverflow.com/questions/tagged/twisted">Stack Overflow</a></h4>
+                  <h4>Ask on
+                    <a href="https://stackoverflow.com/questions/tagged/twisted">
+                      Stack Overflow
+                    </a>
+                  </h4>
                 </div>
               </div>
               <div class="col-md-6 d-flex mb-4 align-items-center">
@@ -430,7 +571,11 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   <i class="icon bi bi-envelope-open text-primary"></i>
                 </div>
                 <div>
-                  <h4>Join the <a href="https://mail.python.org/mailman3/lists/twisted.python.org/">discussion list</a></h4>
+                  <h4>Join the
+                    <a href="https://mail.python.org/mailman3/lists/twisted.python.org/">
+                      discussion list
+                    </a>
+                  </h4>
                 </div>
               </div>
             </div>
@@ -449,7 +594,9 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   <h1>Donate to Twisted</h1>
                   <p>
                     Donations are
-                    <a href="https://twistedmatrix.com/trac/wiki/TwistedSoftwareFoundation#Background" class="text-dark">tax-deductible</a>.
+                    <a href="https://github.com/twisted/trac-wiki-archive/TwistedSoftwareFoundation.mediawiki#Background"
+                      class="text-dark">
+                      tax-deductible</a>.
                   </p>
                 </div>
 
@@ -512,10 +659,14 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
         <div class="row text-center">
           <div class="col">
             <p>
-              Participate in the <a href="https://twistedmatrix.com/trac/wiki/TwistedSoftwareFoundation#BenefitsofSponsorship">Twisted Project Sponsorship Program</a>!
+              Participate in the
+              <a href="https://github.com/twisted/trac-wiki-archive/TwistedSoftwareFoundation.mediawiki#BenefitsofSponsorship">
+                Twisted Project Sponsorship Program</a>!
             </p>
             <p>
-              For <a href="https://twistedmatrix.com/trac/wiki/TwistedSoftwareFoundation#SponsorshipLevels">Silver Sidewinder and higher-level</a> sponsors, we will display your logo here on the front page for one year.
+              For
+              <a href="https://github.com/twisted/trac-wiki-archive/TwistedSoftwareFoundation.mediawiki#SponsorshipLevels">
+                Silver Sidewinder and higher-level</a> sponsors, we will display your logo here on the front page for one year.
             </p>
           </div>
         </div>
@@ -524,7 +675,11 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
 
     <!-- Required vendor scripts (Do not remove) -->
     <script type="text/javascript" src="vendor/js/jquery-v3.5.1.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
+      integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
+      crossorigin="anonymous">
+    </script>
     <script type="text/javascript" src="vendor/js/bootstrap-v4.5.3.min.js"></script>
 
     <script type="text/javascript" src="vendor/js/highlight.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -192,11 +192,11 @@ reactor.run()
                 </pre>
                 <p>
                   Learn more about
-                  <a href="https://twistedmatrix.com/documents/current/core/howto/servers.html">
+                  <a href="https://docs.twistedmatrix.com/en/stable/core/howto/servers.html">
                     writing servers</a>,
-                  <a href="https://twistedmatrix.com/documents/current/core/howto/clients.html">
+                  <a href="https://docs.twistedmatrix.com/en/stable/core/howto/clients.html">
                     writing clients</a> and the
-                  <a href="https://twistedmatrix.com/documents/current/core/howto/index.html">
+                  <a href="https://docs.twistedmatrix.com/en/stable/core/howto/index.html">
                     core networking libraries</a>, including support for
                     SSL, UDP, scheduled events, unit testing infrastructure, and much more.
                 </p>

--- a/index.html
+++ b/index.html
@@ -229,11 +229,11 @@ reactor.run()
                 </pre>
                 <p>
                   Learn more about
-                  <a href="https://twistedmatrix.com/documents/current/web/howto/web-in-60/index.html">
+                  <a href="https://docs.twistedmatrix.com/en/stable/web/howto/web-in-60/index.html">
                     web application development</a>,
-                  <a href="https://twistedmatrix.com/documents/current/web/howto/twisted-templates.html">
+                  <a href="https://docs.twistedmatrix.com/en/stable/web/howto/twisted-templates.html">
                     templates</a> and Twisted's
-                  <a href="https://twistedmatrix.com/documents/current/web/howto/client.html">
+                  <a href="https://docs.twistedmatrix.com/en/stable/web/howto/client.html">
                     HTTP client</a>.
                 </p>
               </div>
@@ -395,7 +395,7 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   documentation
                 </a>
                 and
-                <a class="ext-link" href="https://twistedmatrix.com/documents/current/api/">
+                <a class="ext-link" href="https://docs.twistedmatrix.com/en/stable/api/">
                   API reference</a>.
               </p>
             </div>

--- a/index.html
+++ b/index.html
@@ -175,7 +175,8 @@
             <div class="tab-content" id="nav-tabContent">
               <div class="tab-pane fade show active" id="nav-echo-server" role="tabpanel" aria-labelledby="nav-echo-server-tab">
                 <p>
-                  Twisted makes it easy to implement custom network applications. Here's a TCP server that echoes back everything that's written to it:
+                  Twisted makes it easy to implement custom network applications.
+                  Here's a TCP server that echoes back everything that's written to it:
                 </p>
                 <pre>
                   <code class="language-python" id="server">
@@ -206,7 +207,8 @@ reactor.run()
               </div>
               <div class="tab-pane fade" id="nav-web-server" role="tabpanel" aria-labelledby="nav-web-server-tab">
                 <p>
-                  Twisted includes an event-driven web server. Here's a sample web application; notice how the resource object persists in memory, rather than being recreated on each request:
+                  Twisted includes an event-driven web server. Here's a sample web application;
+                  notice how the resource object persists in memory, rather than being recreated on each request:
                 </p>
                 <pre>
                   <code class="language-python">
@@ -232,7 +234,7 @@ reactor.run()
                   <a href="https://docs.twistedmatrix.com/en/stable/web/howto/web-in-60/index.html">
                     web application development</a>,
                   <a href="https://docs.twistedmatrix.com/en/stable/web/howto/twisted-templates.html">
-                    templates</a> and Twisted's
+                    templates</a> and Twisted'
                   <a href="https://docs.twistedmatrix.com/en/stable/web/howto/client.html">
                     HTTP client</a>.
                 </p>
@@ -310,8 +312,8 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   </code>
                 </pre>
                 <p>
-                  Give this a try, supplying your IMAP4 username, app password (
-                  <a class="ext-link" href="https://support.google.com/accounts/answer/185833?hl=en">generate one for gmail</a>,
+                  Give this a try, supplying your IMAP4 username, app password
+                  (<a class="ext-link" href="https://support.google.com/accounts/answer/185833?hl=en">generate one for gmail</a>,
                   <a class="ext-link" href="https://www.fastmail.com/help/clients/apppassword.html">generate one for fastmail</a>), and
                   <a class="ext-link" href="https://docs.twistedmatrix.com/en/stable/core/howto/endpoints.html">
                     client endpoint description
@@ -411,8 +413,7 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                 </a>
                 through
                 <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedCommunity.mediawiki">
-                  email
-                </a>,
+                  email</a>,
                 <a class="ext-link" href="https://stackoverflow.com/questions/tagged/twisted">
                   Stack Overflow
                 </a>
@@ -505,11 +506,9 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   <p>See the code
                     <a class="ext-link" href="https://github.com/twisted/twisted">
                       <span class="icon"></span>for Twisted
-                    </a> (
-                      <a class="ext-link" href="https://github.com/twisted">
-                        <span class="icon"></span>
-                        and more
-                      </a>) on GitHub.
+                    </a>
+                    (<a class="ext-link" href="https://github.com/twisted"><span class="icon"></span>and more</a>)
+                    on GitHub.
                   </p>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
   <body>
     <header>
-      <div class="navbar-container">
+      <div class="navbar-container layer-2">
         <nav class="navbar navbar-expand-lg justify-content-between navbar-light shadow">
           <div class="container">
             <div class="col flex-fill px-0 d-flex justify-content-between">
@@ -40,7 +40,7 @@
               <ul class="navbar-nav mr-auto">
                 <li class="nav-item">
                   <a class="nav-link"
-                    href="https://github.com/twisted/trac-wiki-archive/FrequentlyAskedQuestions">
+                    href="https://github.com/twisted/trac-wiki-archive/blob/trunk/FrequentlyAskedQuestions.mediawiki">
                     FAQ
                   </a>
                 </li>
@@ -75,11 +75,14 @@
     <img src="assets/images/ribbon.svg" class="ribbon d-none d-md-block">
 
       <div class="container">
-        <div class="row justify-content-center text-center mb-2">
-          <div class="col-xl-10 col-lg-10 col-md-10">
-            <h1 class="display-4">
-              An event-driven networking engine written in Python
+        <div class="row justify-content-center text-center mb-2 layer-2">
+          <div class="col-9 col-xl-12">
+            <h1 class="display-4 font-weight-bold">
+              An event-driven networking engine
             </h1>
+            <h2>
+              Written in Python
+            </h2>
             <p class="lead">Licensed under the open source MIT License</p>
 
             <div class="d-flex flex-md-row flex-column justify-content-center align-items-center my-4">
@@ -310,14 +313,14 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   Give this a try, supplying your IMAP4 username, app password (
                   <a class="ext-link" href="https://support.google.com/accounts/answer/185833?hl=en">generate one for gmail</a>,
                   <a class="ext-link" href="https://www.fastmail.com/help/clients/apppassword.html">generate one for fastmail</a>), and
-                  <a class="ext-link" href="https://twistedmatrix.com/documents/current/core/howto/endpoints.html#auto7">
+                  <a class="ext-link" href="https://docs.twistedmatrix.com/en/stable/core/howto/endpoints.html">
                     client endpoint description
                   </a>
                     for your IMAP4 server.  You'll see the subject of the first message in your mailbox printed.
                 </p>
                 <p>
                   See the
-                  <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/TwistedMail">
+                  <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedMail.mediawiki">
                     TwistedMail
                   </a>
                   documentation for more information.
@@ -403,18 +406,18 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
               <h3>Community</h3>
               <p>
                 Get in touch with the
-                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/TwistedCommunity">
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedCommunity.mediawiki">
                   Twisted community
                 </a>
                 through
-                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/TwistedCommunity.mediawiki#MailLists">
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedCommunity.mediawiki">
                   email
                 </a>,
                 <a class="ext-link" href="https://stackoverflow.com/questions/tagged/twisted">
                   Stack Overflow
                 </a>
                 or
-                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/TwistedCommunity.mediawiki#IRC">
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedCommunity.mediawiki">
                   IRC</a>.
               </p>
             </div>
@@ -425,15 +428,15 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
               <h3>Contribute</h3>
               <p>
                 Learn about the Twisted
-                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/TwistedDevelopment">
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedDevelopment.mediawiki">
                   development process</a>
                   and how to
-                  <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/ContributingToTwistedLabs">
+                  <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/ContributingToTwistedLabs.mediawiki">
                     contribute</a>.
               </p>
               <p>
                 Help improve Twisted on
-                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/Windows">
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/Windows.mediawiki">
                   Windows</a>!
               </p>
             </div>
@@ -446,11 +449,11 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                 Read about
                 <a
                   class="wiki"
-                  href="https://github.com/twisted/trac-wiki-archive/ProjectsUsingTwisted">
+                  href="https://github.com/twisted/trac-wiki-archive/blob/trunk/ProjectsUsingTwisted.mediawiki">
                   software using
                 </a>
                 Twisted and their
-                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/SuccessStories">
+                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/SuccessStories.mediawiki">
                   success stories</a>.
               </p>
             </div>
@@ -463,7 +466,7 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                 Learn about the
                 <a
                   class="wiki"
-                  href="https://github.com/twisted/trac-wiki-archive/TwistedSponsors">
+                  href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedSponsors.mediawiki">
                   individuals and organisations
                 </a>
                 that aid Twisted with donations of hardware, software, hosting and other things.
@@ -478,7 +481,7 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                 Find out what
                 <a
                   class="wiki"
-                  href="https://github.com/twisted/trac-wiki-archive/TwistedMatrixLaboratories">
+                  href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedMatrixLaboratories.mediawiki">
                   Twisted Matrix Laboratories
                 </a>is.
               </p>
@@ -594,7 +597,7 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   <h1>Donate to Twisted</h1>
                   <p>
                     Donations are
-                    <a href="https://github.com/twisted/trac-wiki-archive/TwistedSoftwareFoundation.mediawiki#Background"
+                    <a href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedSoftwareFoundation.mediawiki"
                       class="text-dark">
                       tax-deductible</a>.
                   </p>
@@ -660,12 +663,12 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
           <div class="col">
             <p>
               Participate in the
-              <a href="https://github.com/twisted/trac-wiki-archive/TwistedSoftwareFoundation.mediawiki#BenefitsofSponsorship">
+              <a href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedSoftwareFoundation.mediawiki">
                 Twisted Project Sponsorship Program</a>!
             </p>
             <p>
               For
-              <a href="https://github.com/twisted/trac-wiki-archive/TwistedSoftwareFoundation.mediawiki#SponsorshipLevels">
+              <a href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedSoftwareFoundation.mediawiki#Sponsorship_Levels">
                 Silver Sidewinder and higher-level</a> sponsors, we will display your logo here on the front page for one year.
             </p>
           </div>


### PR DESCRIPTION
Fix #12 

Update wiki links from homepage to go to GitHub wiki.
The links now go to pages from https://github.com/twisted/trac-wiki-archive/

Update links like https://twistedmatrix.com/documents/current/core/howto/servers.html to go to https://docs.twistedmatrix.com/en/stable/core/howto/servers.html

Reviewers: @adiroiban 

