### PR TITLE
 #22 Migrate Twisted Community Page to RTD

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,18 +408,18 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
               <h3>Community</h3>
               <p>
                 Get in touch with the
-                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedCommunity.mediawiki">
+                <a class="wiki" href="https://docs.twisted.org/en/latest/community.html">
                   Twisted community
                 </a>
                 through
-                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedCommunity.mediawiki">
+                <a class="wiki" href="https://docs.twisted.org/en/latest/community.html#mail-lists">
                   email</a>,
                 <a class="ext-link" href="https://stackoverflow.com/questions/tagged/twisted">
                   Stack Overflow
                 </a>
                 or
-                <a class="wiki" href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedCommunity.mediawiki">
-                  IRC</a>.
+                <a class="wiki" href="https://docs.twisted.org/en/latest/community.html#real-time-chat">
+                  Gitter / IRC</a>.
               </p>
             </div>
           </div>


### PR DESCRIPTION
Update links on main page to refer to RTD for the Community Page.