### PR TITLE
report 25 should go to review queue

### DIFF
--- a/assets/js/redirect.js
+++ b/assets/js/redirect.js
@@ -24,7 +24,7 @@ const regex_redirects = [
     ['.*/trac/roadmap$', 'https://github.com/twisted/twisted/milestones'],
     ['.*/trac/newticket$', 'https://github.com/twisted/twisted/issues/new'],
     ['.*/trac/search.*', 'https://github.com/twisted/twisted/issues'],
-    ['.*/trac/report.*', 'https://github.com/twisted/twisted/issues'],
+    ['.*/trac/report.*', 'https://github.com/twisted/twisted/issues?q=is%3Aopen+label%3Aneeds-review+sort%3Aupdated-asc'],
     ['.*/trac/wiki/(.+)', 'https://github.com/twisted/trac-wiki-archive/blob/trunk/$1.mediawiki'],
 ];
 

--- a/assets/js/redirect.js
+++ b/assets/js/redirect.js
@@ -24,7 +24,7 @@ const regex_redirects = [
     ['.*/trac/roadmap$', 'https://github.com/twisted/twisted/milestones'],
     ['.*/trac/newticket$', 'https://github.com/twisted/twisted/issues/new'],
     ['.*/trac/search.*', 'https://github.com/twisted/twisted/issues'],
-    ['.*/trac/report.*', 'https://github.com/twisted/twisted/issues?q=is%3Aopen+label%3Aneeds-review+sort%3Aupdated-asc'],
+    ['.*/trac/report.*', 'https://github.com/pulls?q=is%3Aopen+is%3Apr+archived%3Afalse+team-review-requested%3Atwisted%2Ftwisted-contributors+sort%3Aupdated-asc'],
     ['.*/trac/wiki/(.+)', 'https://github.com/twisted/trac-wiki-archive/blob/trunk/$1.mediawiki'],
 ];
 


### PR DESCRIPTION
correct the redirect URL for `/reports/` to show at least a rough approximation of the current review queue