### PR TITLE
Add link to the new documentation page

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,11 +491,10 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
               <p>
                 Learn about the
                 <a
-                  class="wiki"
-                  href="https://github.com/twisted/trac-wiki-archive/blob/trunk/TwistedSponsors.mediawiki">
+                  href="https://docs.twisted.org/en/latest/development/sponsorship.html">
                   individuals and organisations
                 </a>
-                that aid Twisted with donations of hardware, software, hosting and other things.
+                that aid Twisted with donations and become a sponsor.
               </p>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -494,7 +494,7 @@ task.react(lambda *a, **k: defer.ensureDeferred(main(*a, **k)), sys.argv[1:])
                   href="https://docs.twisted.org/en/latest/development/sponsorship.html">
                   individuals and organisations
                 </a>
-                that aid Twisted with donations and become a sponsor.
+                that sponsor Twisted development.
               </p>
             </div>
           </div>


### PR DESCRIPTION
This replaces the wiki archive link to the new page from Twisted documentation, dedicated to sponsors.

The twisted.org website was done in a hurry...and with the decommissioning of Trac, we used links to the archive wiki.

for the long term, we should replace those wiki links to links to the documentation site

preview link https://deploy-preview-34--twisted-pr-preview.netlify.app/